### PR TITLE
Check for 'Assets' folder before writing

### DIFF
--- a/release_ce_project.py
+++ b/release_ce_project.py
@@ -100,6 +100,8 @@ def package_assets(project_path, export_path):
             continue
 
         if os.path.isfile(itempath):
+            if not os.path.exists(os.path.join(export_path, 'Assets')):
+                os.makedirs(os.path.join(export_path, 'Assets'))
             shutil.copyfile(itempath, os.path.join(output_assetpath, itemname))
         else:
             zip_cmd = ['7z',
@@ -118,6 +120,7 @@ def create_config(export_path):
     with open(os.path.join(export_path, 'system.cfg'), 'w') as fd:
         fd.write('sys_game_folder=Assets\n')
         fd.write('sys_dll_game={}\n'.format(dll_name))
+        fd.write('sys_PakLogInvalidFileAccess=0')
 
 
 def copy_game_dll(project_path, export_path):


### PR DESCRIPTION
Check for 'Assets' folder before writing in package_assets()
Added sys_PakLogInvalidFileAccess=0 to config (needed for third person
shooter in 5.2 to work properly)